### PR TITLE
Corrected shebang lines so that scripts can be run without perl prefix

### DIFF
--- a/ERVcaller_v1.4.pl
+++ b/ERVcaller_v1.4.pl
@@ -1,4 +1,4 @@
-#!usr/bin/env perl
+#!/usr/bin/env perl
 #
 # Author: 	Xun Chen
 # Email: 	Xun.Chen@uvm.edu

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ chr1    5617379 .       T       <INS_MEI:HERV>  .       .       TSD=NULL,NULL;IN
 
 #### Combine multiple samples with providing a list of consensus TE loci  
 ```
-$ perl user_installed_path/Scripts/Combine_VCF_files.pl -l sample_list -c 1KGP.TE.sites.vcf >Output_merged.vcf  
+$ perl user_installed_path/Scripts/Combine_VCF_files.pl -l sample_list -c 1KGP.TE.sites.vcf -o Output_merged.vcf  
 ```
 
 #### Combine multiple samples without providing a list of consensus TE loci  
 ```
-$ perl user_installed_path/Scripts/Combine_VCF_files.pl -l sample_list >Output_merged.vcf  
+$ perl user_installed_path/Scripts/Combine_VCF_files.pl -l sample_list -o Output_merged.vcf  
 ```
 
 #### Calculate the number of reads support non-insertions at the consensus TE loci per sample (It is recommended to filter out low-quality TE loci from the combined VCF file first before running this script)

--- a/Scripts/Break_point_calling.pl
+++ b/Scripts/Break_point_calling.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use Getopt::Long;

--- a/Scripts/Calculate_reads_among_nonTE_locations.pl
+++ b/Scripts/Calculate_reads_among_nonTE_locations.pl
@@ -1,4 +1,4 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
 #
 # Author:       Xun Chen
 # Email:        Xun.Chen@uvm.edu

--- a/Scripts/Check_paired_end.pl
+++ b/Scripts/Check_paired_end.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+
 # This script is to find another end of reads to form PE reads;
 # Usage: perl Fastq_PE_format.pl -sample sample
 #author: Xun Chen

--- a/Scripts/Combine_VCF_files.pl
+++ b/Scripts/Combine_VCF_files.pl
@@ -1,4 +1,4 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
 
 #
 # Author:       Xun Chen

--- a/Scripts/Distinguish_nonTE_from_missing_genotype.pl
+++ b/Scripts/Distinguish_nonTE_from_missing_genotype.pl
@@ -1,4 +1,4 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
 #
 # Author:       Xun Chen
 # Email:        Xun.Chen@uvm.edu

--- a/Scripts/EC_filtered1.pl
+++ b/Scripts/EC_filtered1.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/ERV_Assign_reads-filter.pl
+++ b/Scripts/ERV_Assign_reads-filter.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use Getopt::Long;

--- a/Scripts/ERV_Filtered_fastq.pl
+++ b/Scripts/ERV_Filtered_fastq.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/ERV_Result_visual.pl
+++ b/Scripts/ERV_Result_visual.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 my $line="";
 my @line=();

--- a/Scripts/ERV_filter_reads.pl
+++ b/Scripts/ERV_filter_reads.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/ERV_get_name.pl
+++ b/Scripts/ERV_get_name.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+
 # Author: Xun Chen
 # Email: Xun.Chen@uvm.edu
 

--- a/Scripts/ERV_get_reads.pl
+++ b/Scripts/ERV_get_reads.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 open F1,"$ARGV[0]";

--- a/Scripts/ERV_organize_reads.pl
+++ b/Scripts/ERV_organize_reads.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/Extract_fastq.pl
+++ b/Scripts/Extract_fastq.pl
@@ -1,6 +1,8 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
 
 use strict;
+use warnings;
+
 my %file=();
 my $b1="";
 my $read_name="";

--- a/Scripts/Extract_fastq_sf.pl
+++ b/Scripts/Extract_fastq_sf.pl
@@ -1,6 +1,8 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
 
 use strict;
+use warnings;
+
 my %file=();
 my $b1="";
 my $read_name="";

--- a/Scripts/Extract_specific_loci_final_visualization.pl
+++ b/Scripts/Extract_specific_loci_final_visualization.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my %list=();

--- a/Scripts/Filtered_ERVcaller_1.pl
+++ b/Scripts/Filtered_ERVcaller_1.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/Filtered_fastq.pl
+++ b/Scripts/Filtered_fastq.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/Filtered_integration.pl
+++ b/Scripts/Filtered_integration.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/Filtered_single_reads.pl
+++ b/Scripts/Filtered_single_reads.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use Getopt::Long;

--- a/Scripts/Fine_mapped.pl
+++ b/Scripts/Fine_mapped.pl
@@ -1,4 +1,4 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 
 my $line="";

--- a/Scripts/Order_by_TE_sequence.pl
+++ b/Scripts/Order_by_TE_sequence.pl
@@ -1,5 +1,7 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+
 use strict;
+use warnings;
 use Getopt::Long;
 my %file=();
 my $temp2="";

--- a/Scripts/Reads_summary.pl
+++ b/Scripts/Reads_summary.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use Getopt::Long;

--- a/Scripts/Remove_redundancy_split_reads.pl
+++ b/Scripts/Remove_redundancy_split_reads.pl
@@ -1,4 +1,5 @@
-#!use/bin/perl
+#!/use/bin/env perl
+
 use strict;
 my $line="";
 my @line=();

--- a/Scripts/Result_filtered.pl
+++ b/Scripts/Result_filtered.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line1="";

--- a/Scripts/Result_finalize3.pl
+++ b/Scripts/Result_finalize3.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my $line="";

--- a/Scripts/Results_get.pl
+++ b/Scripts/Results_get.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl
+#!/usr/bin/env perl
+
 use strict;
 
 my @VIP=();

--- a/Scripts/Soft_clipping_transfer.pl
+++ b/Scripts/Soft_clipping_transfer.pl
@@ -1,4 +1,5 @@
-#!usr/bin/perl -w
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
 use Getopt::Long;


### PR DESCRIPTION
Changed ...
#!usr/bin/env perl 
... and ...
#!usr/bin/perl
... lines to ...
#!/usr/bin/env perl

When -w was specified, I added "use warnings;" if it wasn't already there. Also set the executable bits.  This will allow the scripts to be called from the command line without prefixing them with "perl".
